### PR TITLE
Fix Taiwan name (remove "Province of China")

### DIFF
--- a/data.json
+++ b/data.json
@@ -869,7 +869,7 @@
   },
   {
     "code": "TW",
-    "name": "Taiwan, Province of China"
+    "name": "Taiwan"
   },
   {
     "code": "TJ",


### PR DESCRIPTION
In this list, Hong Kong is not even part of China. If that's the case then Taiwan shouldn't also be under province of China.