### PR TITLE
Update SZ country name

### DIFF
--- a/data.json
+++ b/data.json
@@ -853,7 +853,7 @@
   },
   {
     "code": "SZ",
-    "name": "Swaziland"
+    "name": "Eswatini"
   },
   {
     "code": "SE",


### PR DESCRIPTION
Resolve #13.

SZ country name (ex-Swaziland) has been updated to "Eswatini".

**See** https://www.iso.org/obp/ui/#iso:code:3166:SZ.

