### PR TITLE
Retrieve country code using country names without accents

### DIFF
--- a/country-list.js
+++ b/country-list.js
@@ -11,8 +11,8 @@ data.forEach(mapCodeAndName)
 
 function mapCodeAndName (country) {
   nameMap[country.name.toLowerCase()] = country.code
-  codeMap[country.code.toLowerCase()] = country.name
   simpleNameMap[removeDiacritics(country.name.toLowerCase())] = country.code
+  codeMap[country.code.toLowerCase()] = country.name
 }
 
 exports.overwrite = function overwrite (countries) {

--- a/country-list.js
+++ b/country-list.js
@@ -1,15 +1,18 @@
 'use strict'
 
 var data = require('./data.json')
+var removeDiacritics = require('diacritics').remove
 
 /** Precompute name and code lookups. */
 var nameMap = {}
+var simpleNameMap = {}
 var codeMap = {}
 data.forEach(mapCodeAndName)
 
 function mapCodeAndName (country) {
   nameMap[country.name.toLowerCase()] = country.code
   codeMap[country.code.toLowerCase()] = country.name
+  simpleNameMap[removeDiacritics(country.name.toLowerCase())] = country.code
 }
 
 exports.overwrite = function overwrite (countries) {
@@ -25,6 +28,10 @@ exports.overwrite = function overwrite (countries) {
 
 exports.getCode = function getCode (name) {
   return nameMap[name.toLowerCase()]
+}
+
+exports.getCodeSimple = function getCodeSimple (name) {
+  return simpleNameMap[removeDiacritics(name).toLowerCase()]
 }
 
 exports.getName = function getName (code) {
@@ -49,6 +56,10 @@ exports.getCodeList = function getCodeList () {
 
 exports.getNameList = function getNameList () {
   return nameMap
+}
+
+exports.getSimpleNameList = function getSimpleNameList () {
+  return simpleNameMap
 }
 
 exports.getData = function getData () {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "files": [
     "data.json"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "diacritics": "^1.3.0"
+  },
   "devDependencies": {
     "csv-parser": "^1.11.0",
     "standard": "^12.0.1",

--- a/test/get-code-simple.js
+++ b/test/get-code-simple.js
@@ -1,0 +1,13 @@
+'use strict'
+
+var test = require('tap').test
+var countries = require('../')
+
+test('get code from simple country name', function (t) {
+  t.equal(countries.getCodeSimple('aland islands'), 'AX', 'name "aland islands" should return AX')
+  t.equal(countries.getCodeSimple('Cote d\'Ivoire'), 'CI', 'name "Cote d\'Ivoire" should return CI')
+  t.type(countries.getCodeSimple('CI'), 'undefined', 'type of name "CI" is undefined')
+  t.type(countries.getCodeSimple('FarFarAwayLand'), 'undefined', 'name "FarFarAwayLand" should return undefined')
+  t.type(countries.getCodeSimple(''), 'undefined', 'empty name should return undefined')
+  t.end()
+})

--- a/test/get-simple-name-list.js
+++ b/test/get-simple-name-list.js
@@ -1,0 +1,14 @@
+'use strict'
+
+var test = require('tap').test
+var countries = require('../')
+var data = require('../data.json')
+
+test('get all simple country names with code as key', function (t) {
+  var list = countries.getSimpleNameList()
+
+  t.type(list, Object, 'country name list is an object')
+  t.equal(Object.keys(list).length, data.length, 'country name list should be as many as countries')
+  t.equal(list['aland islands'], 'AX', 'aland islands must be equal to AX code')
+  t.end()
+})


### PR DESCRIPTION
I ran into a problem using your package in a project where I'm trying to convert user input to country codes. If the input didn't have the accents the actual country name has (like Åland/Aland, which happens a lot) the conversion wouldn't work, so I added a few functions to improve the use of this package in my project.