### PR TITLE
Shorten GB display name

### DIFF
--- a/data.json
+++ b/data.json
@@ -75,7 +75,7 @@
   { "code": "FO", "name": "Faroe Islands" },
   { "code": "FR", "name": "France" },
   { "code": "GA", "name": "Gabon" },
-  { "code": "GB", "name": "United Kingdom of Great Britain and Northern Ireland" },
+  { "code": "GB", "name": "United Kingdom" },
   { "code": "GD", "name": "Grenada" },
   { "code": "GE", "name": "Georgia" },
   { "code": "GF", "name": "French Guiana" },


### PR DESCRIPTION
The recently changed GB display name is:

- A. Too long to fit in most UIs
- B. An unfamiliar way to refer to UK. I live in UK and have never heard it called that.