### PR TITLE
Fixed incorrect name of Taiwan.

### DIFF
--- a/data.json
+++ b/data.json
@@ -226,7 +226,7 @@
   { "code": "TR", "name": "Turkey" },
   { "code": "TT", "name": "Trinidad and Tobago" },
   { "code": "TV", "name": "Tuvalu" },
-  { "code": "TW", "name": "Taiwan, Province of China" },
+  { "code": "TW", "name": "Taiwan" },
   { "code": "TZ", "name": "Tanzania, United Republic of" },
   { "code": "UA", "name": "Ukraine" },
   { "code": "UG", "name": "Uganda" },


### PR DESCRIPTION
Using `Taiwan, Province of China` is a pollitical message and incorrect.

The official name of Taiwan is `Republic of Taiwan`, however it is often abbreviated to Taiwan. 

