### PR TITLE
fix: node incompatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Maps ISO 3166-1-alpha-2 codes to English country names and vice versa.",
   "main": "country-list.js",
   "engines": {
-    "node": "18.x"
+    "node": ">=18"
   },
   "files": [
     "data.json"


### PR DESCRIPTION
Whitelisted all node version >=18, so we get rid of the `BAD ENGINE` warning.

Fixes: #53 
